### PR TITLE
1993年の敬老の日は9月15日

### DIFF
--- a/holidays.yml
+++ b/holidays.yml
@@ -2308,10 +2308,10 @@
   name: 皇太子徳仁親王の結婚の儀
   name_en: "The Rite of Wedding of HIH Crown Prince Naruhito"
 
-1993-09-05:
-  date: 1993-09-05
-  week: 日
-  week_en: Sunday
+1993-09-15:
+  date: 1993-09-15
+  week: 水
+  week_en: Wednesday
   name: 敬老の日
   name_en: "Respect for the Aged Day"
 


### PR DESCRIPTION
2003年よりまえの敬老の日は 9月15日で固定ですので、9月5日ではなく9月15日が正しいと思われます。